### PR TITLE
♻️ Improve the clarity of the public API

### DIFF
--- a/src/detail.rs
+++ b/src/detail.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+struct PipelineStage<S, F, Next> {
+    stage: S,
+    callback: F,
+    next: Next,
+}
+
+pub(crate) struct PipelineEnd<S, F> {
+    stage: S,
+    callback: F,
+}
+
+impl<S, F> PipelineEnd<S, F> {
+    pub(crate) fn new(stage: S, callback: F) -> Self {
+        Self { stage, callback }
+    }
+}
+
+impl<PS, PF, PR, Error> Pipeline<Error> for PipelineEnd<PS, PF>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+{
+    fn and_then<S, F, R>(
+        self,
+        stage: S,
+        callback: F,
+    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
+    where
+        S: Stage<Error, Input = Self::End>,
+        F: FnOnce(&S::Output) -> R,
+        R: Into<Continue>,
+    {
+        PipelineStage {
+            stage: self.stage,
+            callback: self.callback,
+            next: PipelineEnd { stage, callback },
+        }
+    }
+}
+
+impl<PS, PF, PR, Next, Error> Pipeline<Error> for PipelineStage<PS, PF, Next>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+    Next: Pipeline<Error, Start = PS::Output>,
+{
+    fn and_then<S, F, R>(
+        self,
+        stage: S,
+        callback: F,
+    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
+    where
+        S: Stage<Error, Input = Self::End>,
+        F: FnOnce(&S::Output) -> R,
+        R: Into<Continue>,
+    {
+        PipelineStage {
+            stage: self.stage,
+            callback: self.callback,
+            next: self.next.and_then(stage, callback),
+        }
+    }
+}
+
+impl<PS, PF, PR, Error> RunPipeline<Error> for PipelineEnd<PS, PF>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+{
+    type Start = PS::Input;
+    type End = PS::Output;
+
+    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
+        match self.stage.run(input) {
+            Ok(output) => match (self.callback)(&output).into() {
+                Continue::Continue => PipelineResult::Ok(output),
+                Continue::Cancel => PipelineResult::Cancelled,
+            },
+
+            Err(err) => PipelineResult::Err(err),
+        }
+    }
+}
+
+impl<PS, PF, PR, Error, Next> RunPipeline<Error> for PipelineStage<PS, PF, Next>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+    Next: RunPipeline<Error, Start = PS::Output>,
+{
+    type Start = PS::Input;
+    type End = Next::End;
+
+    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
+        match self.stage.run(input) {
+            Ok(output) => match (self.callback)(&output).into() {
+                Continue::Continue => self.next.run(output),
+                Continue::Cancel => PipelineResult::Cancelled,
+            },
+
+            Err(err) => PipelineResult::Err(err),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod detail;
+
 #[derive(Debug)]
 pub enum PipelineResult<T, E> {
     Ok(T),
@@ -52,110 +54,7 @@ where
     FR: Into<Continue>,
     F: FnOnce(&S::Output) -> FR,
 {
-    PipelineEnd { stage, callback }
-}
-
-struct PipelineStage<S, F, Next> {
-    stage: S,
-    callback: F,
-    next: Next,
-}
-
-struct PipelineEnd<S, F> {
-    stage: S,
-    callback: F,
-}
-
-impl<PS, PF, PR, Error> Pipeline<Error> for PipelineEnd<PS, PF>
-where
-    PS: Stage<Error>,
-    PF: FnOnce(&PS::Output) -> PR,
-    PR: Into<Continue>,
-{
-    fn and_then<S, F, R>(
-        self,
-        stage: S,
-        callback: F,
-    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
-    where
-        S: Stage<Error, Input = Self::End>,
-        F: FnOnce(&S::Output) -> R,
-        R: Into<Continue>,
-    {
-        PipelineStage {
-            stage: self.stage,
-            callback: self.callback,
-            next: PipelineEnd { stage, callback },
-        }
-    }
-}
-
-impl<PS, PF, PR, Next, Error> Pipeline<Error> for PipelineStage<PS, PF, Next>
-where
-    PS: Stage<Error>,
-    PF: FnOnce(&PS::Output) -> PR,
-    PR: Into<Continue>,
-    Next: Pipeline<Error, Start = PS::Output>,
-{
-    fn and_then<S, F, R>(
-        self,
-        stage: S,
-        callback: F,
-    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
-    where
-        S: Stage<Error, Input = Self::End>,
-        F: FnOnce(&S::Output) -> R,
-        R: Into<Continue>,
-    {
-        PipelineStage {
-            stage: self.stage,
-            callback: self.callback,
-            next: self.next.and_then(stage, callback),
-        }
-    }
-}
-
-impl<PS, PF, PR, Error> RunPipeline<Error> for PipelineEnd<PS, PF>
-where
-    PS: Stage<Error>,
-    PF: FnOnce(&PS::Output) -> PR,
-    PR: Into<Continue>,
-{
-    type Start = PS::Input;
-    type End = PS::Output;
-
-    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
-        match self.stage.run(input) {
-            Ok(output) => match (self.callback)(&output).into() {
-                Continue::Continue => PipelineResult::Ok(output),
-                Continue::Cancel => PipelineResult::Cancelled,
-            },
-
-            Err(err) => PipelineResult::Err(err),
-        }
-    }
-}
-
-impl<PS, PF, PR, Error, Next> RunPipeline<Error> for PipelineStage<PS, PF, Next>
-where
-    PS: Stage<Error>,
-    PF: FnOnce(&PS::Output) -> PR,
-    PR: Into<Continue>,
-    Next: RunPipeline<Error, Start = PS::Output>,
-{
-    type Start = PS::Input;
-    type End = Next::End;
-
-    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
-        match self.stage.run(input) {
-            Ok(output) => match (self.callback)(&output).into() {
-                Continue::Continue => self.next.run(output),
-                Continue::Cancel => PipelineResult::Cancelled,
-            },
-
-            Err(err) => PipelineResult::Err(err),
-        }
-    }
+    detail::PipelineEnd::new(stage, callback)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 #[derive(Debug)]
-pub enum Err<E> {
+pub enum PipelineResult<T, E> {
+    Ok(T),
+    Err(E),
     Cancelled,
-    Err(E)
 }
 
 #[derive(Debug)]
 pub enum Continue {
     Continue,
-    Cancel
+    Cancel,
 }
 
 impl From<()> for Continue {
@@ -27,127 +28,133 @@ pub trait RunPipeline<Error> {
     type Start;
     type End;
 
-    fn run(self, input: Self::Start) -> Result<Self::End, Err<Error>>;
+    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error>;
 }
 
-pub trait Pipeline<Error, S, FR, F>: RunPipeline<Error>
+pub trait Pipeline<Error>: RunPipeline<Error> {
+    fn and_then<S, F, R>(
+        self,
+        stage: S,
+        callback: F,
+    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
     where
-        S: Stage<Error, Input=Self::End>,
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR {
-
-    type AndThen;
-
-    fn and_then(self, stage: S, callback: F) -> Self::AndThen;
+        S: Stage<Error, Input = Self::End>,
+        F: FnOnce(&S::Output) -> R,
+        R: Into<Continue>;
 }
 
-pub struct PipelineStage<S, F, Next> {
+pub fn pipeline<S, FR, F, Error>(
     stage: S,
     callback: F,
-    next: Next
+) -> impl Pipeline<Error, Start = S::Input, End = S::Output>
+where
+    S: Stage<Error>,
+    FR: Into<Continue>,
+    F: FnOnce(&S::Output) -> FR,
+{
+    PipelineEnd { stage, callback }
 }
 
-pub struct PipelineEnd<S, F> {
+struct PipelineStage<S, F, Next> {
     stage: S,
-    callback: F
+    callback: F,
+    next: Next,
 }
 
-impl<S, FR, F, Error, T, GR, G> Pipeline<Error, T, GR, G> for PipelineEnd<S, F> 
-    where 
-        S: Stage<Error>,
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR,
-        T: Stage<Error, Input=S::Output>,
-        GR: Into<Continue>,
-        G: FnOnce(&T::Output) -> GR {
-
-    type AndThen = PipelineStage<S, F, PipelineEnd<T, G>>;
-
-    fn and_then(self, stage: T, callback: G) -> Self::AndThen {
-        PipelineStage {
-            stage: self.stage,
-            callback: self.callback,
-            next: PipelineEnd {
-                stage,
-                callback,
-            }
-        }
-    }
+struct PipelineEnd<S, F> {
+    stage: S,
+    callback: F,
 }
 
-impl<S, FR, F, P, Error, T, GR, G> Pipeline<Error, T, GR, G> for PipelineStage<S, F, P> 
-    where 
-        S: Stage<Error, Output=P::Start>, 
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR, 
-        P: Pipeline<Error, T, GR, G>,
-        T: Stage<Error, Input=P::End>,
-        GR: Into<Continue>,
-        G: FnOnce(&T::Output) -> GR {
-
-    type AndThen = PipelineStage<S, F, P::AndThen>;
-
-    fn and_then(self, stage: T, callback: G) -> Self::AndThen {
-        PipelineStage {
-            stage: self.stage,
-            callback: self.callback,
-            next: self.next.and_then(stage, callback)
-        }
-    }
-}
-
-impl<S, FR, F, Error> RunPipeline<Error> for PipelineEnd<S, F>
+impl<PS, PF, PR, Error> Pipeline<Error> for PipelineEnd<PS, PF>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+{
+    fn and_then<S, F, R>(
+        self,
+        stage: S,
+        callback: F,
+    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
     where
-        S: Stage<Error>,
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR {
+        S: Stage<Error, Input = Self::End>,
+        F: FnOnce(&S::Output) -> R,
+        R: Into<Continue>,
+    {
+        PipelineStage {
+            stage: self.stage,
+            callback: self.callback,
+            next: PipelineEnd { stage, callback },
+        }
+    }
+}
 
-    type Start = S::Input;
-    type End = S::Output;
+impl<PS, PF, PR, Next, Error> Pipeline<Error> for PipelineStage<PS, PF, Next>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+    Next: Pipeline<Error, Start = PS::Output>,
+{
+    fn and_then<S, F, R>(
+        self,
+        stage: S,
+        callback: F,
+    ) -> impl Pipeline<Error, Start = Self::Start, End = S::Output>
+    where
+        S: Stage<Error, Input = Self::End>,
+        F: FnOnce(&S::Output) -> R,
+        R: Into<Continue>,
+    {
+        PipelineStage {
+            stage: self.stage,
+            callback: self.callback,
+            next: self.next.and_then(stage, callback),
+        }
+    }
+}
 
-    fn run(self, input: Self::Start) -> Result<Self::End, Err<Error>> {
+impl<PS, PF, PR, Error> RunPipeline<Error> for PipelineEnd<PS, PF>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+{
+    type Start = PS::Input;
+    type End = PS::Output;
+
+    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
         match self.stage.run(input) {
             Ok(output) => match (self.callback)(&output).into() {
-                Continue::Continue => Ok(output),
-                Continue::Cancel => Err(Err::Cancelled)
+                Continue::Continue => PipelineResult::Ok(output),
+                Continue::Cancel => PipelineResult::Cancelled,
             },
 
-            Err(err) => Err(Err::Err(err))
+            Err(err) => PipelineResult::Err(err),
         }
     }
 }
 
-impl<S, FR, F, Error, P> RunPipeline<Error> for PipelineStage<S, F, P>
-    where
-        S: Stage<Error>,
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR,
-        P: RunPipeline<Error, Start=S::Output> {
+impl<PS, PF, PR, Error, Next> RunPipeline<Error> for PipelineStage<PS, PF, Next>
+where
+    PS: Stage<Error>,
+    PF: FnOnce(&PS::Output) -> PR,
+    PR: Into<Continue>,
+    Next: RunPipeline<Error, Start = PS::Output>,
+{
+    type Start = PS::Input;
+    type End = Next::End;
 
-    type Start = S::Input;
-    type End = P::End;
-
-    fn run(self, input: Self::Start) -> Result<Self::End, Err<Error>> {
+    fn run(self, input: Self::Start) -> PipelineResult<Self::End, Error> {
         match self.stage.run(input) {
             Ok(output) => match (self.callback)(&output).into() {
                 Continue::Continue => self.next.run(output),
-                Continue::Cancel => Err(Err::Cancelled)
+                Continue::Cancel => PipelineResult::Cancelled,
             },
 
-            Err(err) => Err(Err::Err(err)),
+            Err(err) => PipelineResult::Err(err),
         }
-    }
-}
-
-pub fn pipeline<S, FR, F, Error>(stage: S, callback: F) -> PipelineEnd<S, F>
-    where
-        S: Stage<Error>,
-        FR: Into<Continue>,
-        F: FnOnce(&S::Output) -> FR {
-
-    PipelineEnd {
-        stage,
-        callback
     }
 }
 
@@ -174,21 +181,33 @@ mod test {
 
         fn run(self, input: Vec<i64>) -> Result<String, std::fmt::Error> {
             let mut s = String::new();
-            input.into_iter().map(|i| write!(s, "{}", i)).collect::<Result<Vec<_>, _>>().map(|_| s)
+            input
+                .into_iter()
+                .map(|i| write!(s, "{}", i))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|_| s)
         }
     }
 
     #[test]
     fn run_test() {
-        println!("{:?}", pipeline(StageA, |v| for i in v { println!("{}", i)})
+        println!(
+            "{:?}",
+            pipeline(StageA, |v| for i in v {
+                println!("{}", i)
+            })
             .and_then(StageB, |_| {})
-            .run(()))
+            .run(())
+        )
     }
 
     #[test]
     fn cancel_test() {
-        println!("{:?}", pipeline(StageA, |_| Continue::Cancel)
-            .and_then(StageB, |_| {})
-            .run(()))
+        println!(
+            "{:?}",
+            pipeline(StageA, |_| Continue::Cancel)
+                .and_then(StageB, |_| {})
+                .run(())
+        )
     }
 }


### PR DESCRIPTION
This PR makes use of return-type `impl Trait` in traits to simplify the traits and remove some atrocious `where` clauses